### PR TITLE
Patch API spec to allow NULL default_hierarchy module parameter.

### DIFF
--- a/R/check_call_auto.R
+++ b/R/check_call_auto.R
@@ -23,7 +23,7 @@ check_mod_hierarchical_count_table_auto <- function(afmm, datasets, module_id, t
     "      The expectation is that it either does not require them or that"
     "      the caller of this function has written manual checks near the call site."
     subkind <- list(kind = "or", options = list(list(kind = "character"), list(kind = "factor")))
-    flags <- list(zero_or_more = TRUE)
+    flags <- list(zero_or_more = TRUE, optional = TRUE)
     OK[["default_hierarchy"]] <- OK[["table_dataset_name"]] && CM$check_dataset_colum_name("default_hierarchy",
         default_hierarchy, subkind, flags, table_dataset_name, datasets[[table_dataset_name]], warn,
         err)

--- a/R/mod_hierarchical_count_table.R
+++ b/R/mod_hierarchical_count_table.R
@@ -671,7 +671,8 @@ mod_hierarchical_count_table_API_spec <- TC$group(
   pop_dataset_name = TC$dataset_name(),
   subjid_var = TC$col("pop_dataset_name", TC$factor()) |> TC$flag("subjid_var"),
   show_modal_on_click = TC$logical(),
-  default_hierarchy = TC$col("table_dataset_name", TC$or(TC$character(), TC$factor())) |> TC$flag("zero_or_more"),
+  default_hierarchy = TC$col("table_dataset_name", TC$or(TC$character(), TC$factor())) |> 
+    TC$flag("zero_or_more", "optional"),
   default_group = TC$col("pop_dataset_name", TC$or(TC$character(), TC$factor())) |> TC$flag("optional"),
   intended_use_label = TC$character() |> TC$flag("optional"),
   receiver_id = TC$character() |> TC$flag("optional")


### PR DESCRIPTION
According to the documentation, `default_hierarchy` was not required. However, the application threw an early error feedback when it was missing. This issue has been resolved by marking the argument as optional in the module checker.