### PR TITLE
Guard against multiple instances of review-enabled mod_listings and/or mod_Tplyr_tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.tables
 Type: Package
 Title: Table Modules
-Version: 0.2.0-9000
+Version: 0.2.0-9001
 Authors@R: c(
         person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
         person(given = "Luis", family = "Moris Fernandez", role = c("aut", "cre"), email = "luis.moris.fernandez@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# dv.tables 0.2.0-9000
+# dv.tables 0.2.0-9001
 
 * Remove pharmaverseadam dependency
 

--- a/R/mod_Tplyr_table.R
+++ b/R/mod_Tplyr_table.R
@@ -542,6 +542,35 @@ mod_Tplyr_table <- function(
         on_sbj_click_fun <- function() afmm[["utils"]][["switch2mod"]](receiver_id)
       }
 
+      if (is.list(review)) {
+        # Prevent and warn against multiple `dv.tables` instances with active review functionality.
+        #
+        # This block of code takes advantage of the way `dv.manager` incrementally populates afmm[["module_output"]].
+        # At this point in (non-reactive) time, `dv.manager` has run the server functions of only the modules that
+        # precede this one in the `module_list` declaration of the DaVinci app. As long as one of them has declared
+        # that it offers the review interface, we will refuse to start our own.
+        # The mod_output[["enabled_review]] flag is set by `dv.listings::listings_server`.
+        for (mod_output in afmm[["module_output"]]()){
+          if (is.list(mod_output) && isTRUE(mod_output[["enabled_review"]])) {
+            this_tab_name <- afmm[["module_names"]][[module_id]]
+            
+            shiny::showNotification({
+              paste(
+                "This app is configured to review listings in more than one tab. However,",
+                "only one instance of the `dv.tables` module can offer review functionality on any given app.<br>",
+                sprintf(
+                  'We have <b>disabled the review interface on the tab labeled "%s" (with module ID "%s")</b>',
+                  this_tab_name, module_id
+                ), "to sidestep this issue. Sorry for the inconvenience."
+              ) |> htmltools::HTML()
+            }, duration = NULL, type = "error")
+            
+            review <- NULL
+            break
+          }
+        }
+      }
+
       needed_datasets <- sapply(output_list, function(tab) {
         if ("tplyr_tab_fun" %in% names(tab)) {
           names(formals(tab[["tplyr_tab_fun"]]))


### PR DESCRIPTION
Here's what app creators (and possibly users) will see when they launch an app with two dv.tables configured for review:
<img width="526" height="436" alt="image" src="https://github.com/user-attachments/assets/fe5536c7-0330-4d04-bd09-58bcb32f0564" />

`listings_server` returns a boolean flag indicating that it is configured for review. Since `mod_Tplyr_tables` allows the output of `listings_server` to go through, this module inherits that behavior.

During module set up, any listings or tables module instance can check if there is another module offering a review interface. If that is the case, they inhibit their own review functionality and raise the error message.

I'm not a fan of the way `mod_Tplyr_tables` wraps the `dv.listings` server function, but I have to admit that our team is doing something right when the error checking across modules composes into a solution this simple :).

# Hotfix checklist

- [ ] Bumped minor version number on both DESCRIPTION and NEWS.md

- [ ] Build passes pipeline checks

- [ ] The new changes do not affect the API

- [ ] The new changes do not affect the documentation (including screenshots)

- [ ] The new changes do not impact the QC report