### PR TITLE
[review] Provide `afmm` to newer version of `dv.listings::check_review_parameter`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.tables
 Type: Package
 Title: Table Modules
-Version: 0.4.1-9002
+Version: 0.4.1-9003
 Authors@R: c(
         person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
         person(given = "Luis", family = "Moris Fernandez", role = c("aut", "cre"), email = "luis.moris.fernandez@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# dv.tables 0.4.1-9003
+
+- [NOT USER-FACING] Provide `afmm` to newer version of `dv.listings::check_review_parameter`
+
 # dv.tables 0.4.1-9002
 
-- Add progress bar shown during table generation.
+- Add progress bar shown during table generation
 
 # dv.tables 0.4.1-9001
 

--- a/R/mod_Tplyr_table.R
+++ b/R/mod_Tplyr_table.R
@@ -752,15 +752,20 @@ check_mod_Tplyr_table <- function(
   #   afmm, datasets, module_id, output_list, subjid_var, default_vars, pagination, intended_use_label,
   #   receiver_id, review, err
   # )
-  # nolint stop
+  # nolint end
 
-  dv.listings::check_review_parameter(
-    datasets = datasets,
-    dataset_names = names(review[["datasets"]]),
-    review,
-    err
+  check_review_parameter_args <- list(
+      datasets = datasets,
+      dataset_names = names(review[["datasets"]]),
+      review = review,
+      err = err
   )
-
+  if ("afmm" %in% names(formals(dv.listings::check_review_parameter))) {
+    check_review_parameter_args[["afmm"]] <- afmm
+  } 
+  
+  do.call(dv.listings::check_review_parameter, check_review_parameter_args)
+  
   res <- list(errors = err[["messages"]])
   return(res)
 }


### PR DESCRIPTION
This is a companion PR to [this other one](https://github.com/Boehringer-Ingelheim/dv.listings/pull/68) in `dv.listings`. There is no preferential order of review.

It takes advantage of the extra `afmm` parameter in `dv.listings::check_review_parameter` (if available), so that the names of dataset lists and datasets can be checked for characters that would interfere with the review process. The best example is the use of the `/` slash character. If a dataset name contains one of those, the file creation logic in `dv.listings` will treat those as part of the filename and the filesystem will throw an error, as they are illegal for file names.

# Critical checks

- [ ] Is the test version number correct (x.x.x-9000)? 

- [ ] DESCRIPTION file

- [ ] NEWS.md

- [ ] Does the build pass?

---

## Documentation

Does it include the following sections?

- [ ] Module introduction with features
  - [ ] (O) Screenshots

- [ ] Installation details

- [ ] Explanation of function arguments

- [ ] Data specifications and requirements

- [ ] Different possible visualizations

- [ ] Are the changes/new features included in NEWS.md?
  - [ ] (O) Screenshots

- [ ] (O) Explanation of input menus

- [ ] (O) Short articles on building the app, compatibility with other modules, known bugs,...

---

## QC Report

- [ ] Does it include a QC Report with positive outcome?

- [ ] Are the new features reflected accordingly in the specs?

---

## API conventions

- [ ] Follows API convention
