### PR TITLE
CSS tweak to adapt mod_Tplyr to changes in dv.listings.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.tables
 Type: Package
 Title: Table Modules
-Version: 0.4.1-9004
+Version: 0.4.1-9005
 Authors@R: c(
         person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
         person(given = "Luis", family = "Moris Fernandez", role = c("aut", "cre"), email = "luis.moris.fernandez@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.tables 0.4.1-9005
+
+- [NOT USER-FACING] CSS tweak to container of dv.listings Tplyr_table.
+
 # dv.tables 0.4.1-9004
 
 - Add scrollbar to options dropdown to avoid truncation in short window space.

--- a/R/mod_Tplyr_table.R
+++ b/R/mod_Tplyr_table.R
@@ -29,7 +29,8 @@ Tplyr_table_UI <- function(module_id, output_list) {
     shiny::br(),
     shiny::uiOutput(ns(TPLYR_TBL$LISTINGS_HEADER_ID)),
     shiny::br(),
-    shiny::div(id = ns(TPLYR_TBL$LISTINGS_DIV_ID), dv.listings::listings_UI(ns(TPLYR_TBL$LISTINGS_ID)))
+    shiny::div(id = ns(TPLYR_TBL$LISTINGS_DIV_ID), style = "height:100%",
+               dv.listings::listings_UI(ns(TPLYR_TBL$LISTINGS_ID)))
   )
 
   return(ui)


### PR DESCRIPTION
After recent changes to `dv.listings`, the style of the `<div>` surrounding the listing needs a bit of tweaking.
This is related to [this commit](https://github.com/Boehringer-Ingelheim/dv.listings/pull/71/commits/0241aabc47a7be6919d8baae82822877548df0b5) in [this dv.listings PR](https://github.com/Boehringer-Ingelheim/dv.listings/pull/71).

# Hotfix checklist

- [ ] Bumped minor version number on both DESCRIPTION and NEWS.md

- [ ] Build passes pipeline checks

- [ ] The new changes do not affect the API

- [ ] The new changes do not affect the documentation (including screenshots)

- [ ] The new changes do not impact the QC report

